### PR TITLE
Fix macOS CI: bump @vscode/test-electron to ^3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/sinonjs__fake-timers": "^8.1.5",
         "@types/vscode": "^1.85.0",
         "@vscode/test-cli": "^0.0.15",
-        "@vscode/test-electron": "^2.5.2",
+        "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.9.2",
         "sinon": "^21.0.0",
         "typescript": "^5.3.3"
@@ -1038,9 +1038,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1051,7 +1051,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/vsce": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@types/sinonjs__fake-timers": "^8.1.5",
     "@types/vscode": "^1.85.0",
     "@vscode/test-cli": "^0.0.15",
-    "@vscode/test-electron": "^2.5.2",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.9.2",
     "sinon": "^21.0.0",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Problem

The macOS `Node.js Test` job fails on every PR (e.g. #26), blocking merges:

```
Test error: Error: spawn .../.vscode-test/vscode-darwin-arm64-1.132.0/Visual Studio Code.app/Contents/MacOS/Electron ENOENT
Exit code: -2
```

## Cause

VS Code 1.110 renamed the macOS main binary from `Contents/MacOS/Electron` to
`Contents/MacOS/Code` (microsoft/vscode#291948), and the backwards-compatible
symlink was later removed in microsoft/vscode#326502.

`@vscode/test-electron` 2.x hardcodes the old `Electron` path, so launching a
1.132.0 download fails. 3.x resolves the executable from the bundle's
`Info.plist` (`CFBundleExecutable`) instead — see microsoft/vscode-test#348
and #349.

Confirmed against the bundles already downloaded locally (darwin-arm64):

| VS Code | `Contents/MacOS/` |
| --- | --- |
| 1.85.1 / 1.103.0 / 1.103.1 | `Electron` |
| 1.132.0 | `Code` |

This is unrelated to the fast-uri bump in #26; it is a regression caused by the
VS Code stable release, and `main` is affected too.

## Change

- Bump `@vscode/test-electron` from `^2.5.2` to `^3.1.0`

Note that `@vscode/test-cli@0.0.15` also expects `@vscode/test-electron: ^3.0.0`.

## Verification

- `npm test` passes locally on macOS (15 passing, VS Code 1.132.0)
- `npm run lint:ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)