### PR TITLE
fix: overwrite only the gaming targets in workbench.colorCustomizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "vscode-gaming" extension will be documented in this 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## Unreleased
+
+* Fixed gaming mode overwriting color customizations outside of `gaming.targets`
+* Fixed reset changing `workbench.colorCustomizations` when gaming mode had never been started
+
 ## 0.1.0
 
 * Added reset command

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,13 +14,27 @@ function getColorCustomizations(): ColorCustomizations | undefined {
 }
 
 function updateColorCustomizations(customizations: ColorCustomizations): Thenable<void> {
-  return vscode.workspace.getConfiguration().update(COLOR_CUSTOMIZATIONS, customizations, true);
+  // Writing an empty object would leave a `"workbench.colorCustomizations": {}` block behind in
+  // settings.json. Passing undefined drops the entry instead.
+  const value = Object.keys(customizations).length > 0 ? customizations : undefined;
+
+  return vscode.workspace.getConfiguration().update(COLOR_CUSTOMIZATIONS, value, true);
 }
 
 export function activate(context: vscode.ExtensionContext) {
   // The values the targets held before gaming mode overwrote them. Reset puts back these entries
   // only, so customizations outside of `gaming.targets` are never touched.
   let originalTargets: TargetSnapshot = new Map();
+
+  // The write started by the most recent tick. Nothing awaits a tick, so it is tracked here for
+  // reset to wait on, and its failure is reported here rather than left as an unhandled rejection.
+  let pendingUpdate: Promise<void> = Promise.resolve();
+
+  function updateFromTick(customizations: ColorCustomizations): void {
+    pendingUpdate = Promise.resolve(updateColorCustomizations(customizations)).then(undefined, (error) => {
+      console.error('vscode-gaming: failed to update color customizations', error);
+    });
+  }
 
   const startCmd = vscode.commands.registerCommand('vscode-gaming.start', () => {
     const config = new Config();
@@ -37,7 +51,7 @@ export function activate(context: vscode.ExtensionContext) {
     // the animation writes always match the ones recorded in `originalTargets`.
     timer.start(() => {
       const color = ColorWheel.at(shift);
-      updateColorCustomizations(TargetColors.apply(getColorCustomizations(), config.targets, color.code()));
+      updateFromTick(TargetColors.apply(getColorCustomizations(), config.targets, color.code()));
 
       shift += delta;
     }, config.updateTime);
@@ -56,6 +70,10 @@ export function activate(context: vscode.ExtensionContext) {
     if (originalTargets.size === 0) {
       return;
     }
+
+    // Stopping the timer does not stop a tick that is already writing. Let it settle first,
+    // otherwise it could land after the restore and put a gaming color back.
+    await pendingUpdate;
 
     await updateColorCustomizations(TargetColors.restore(getColorCustomizations(), originalTargets));
     originalTargets = new Map();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,13 +2,27 @@ import * as vscode from 'vscode';
 
 import { ColorWheel } from './colorwheel';
 import { Config } from './config';
+import { type ColorCustomizations, TargetColors, type TargetSnapshot } from './targetcolors';
 import { Timer } from './timer';
 
+const COLOR_CUSTOMIZATIONS = 'workbench.colorCustomizations';
+
+// `WorkspaceConfiguration` is a snapshot rather than a live view, so it is re-read on every access
+// to make sure customizations written after it was obtained are not dropped.
+function getColorCustomizations(): ColorCustomizations | undefined {
+  return vscode.workspace.getConfiguration().get<ColorCustomizations>(COLOR_CUSTOMIZATIONS);
+}
+
+function updateColorCustomizations(customizations: ColorCustomizations): Thenable<void> {
+  return vscode.workspace.getConfiguration().update(COLOR_CUSTOMIZATIONS, customizations, true);
+}
+
 export function activate(context: vscode.ExtensionContext) {
-  let originalCustomizations = vscode.workspace.getConfiguration().get('workbench.colorCustomizations');
+  // The values the targets held before gaming mode overwrote them. Reset puts back these entries
+  // only, so customizations outside of `gaming.targets` are never touched.
+  let originalTargets: TargetSnapshot = new Map();
 
   const startCmd = vscode.commands.registerCommand('vscode-gaming.start', () => {
-    const globalConfig = vscode.workspace.getConfiguration();
     const config = new Config();
 
     const delta = config.delta();
@@ -16,14 +30,14 @@ export function activate(context: vscode.ExtensionContext) {
 
     const timer = Timer.getInstance();
     if (!timer.isRunning()) {
-      originalCustomizations = globalConfig.get('workbench.colorCustomizations');
+      originalTargets = TargetColors.snapshot(getColorCustomizations(), config.targets);
     }
 
+    // `config.targets` is captured here instead of being re-read on every tick, so that the targets
+    // the animation writes always match the ones recorded in `originalTargets`.
     timer.start(() => {
       const color = ColorWheel.at(shift);
-      const entries = config.targets.map((target) => [target, color.code()]);
-      const customizations = Object.fromEntries(entries);
-      globalConfig.update('workbench.colorCustomizations', customizations, true);
+      updateColorCustomizations(TargetColors.apply(getColorCustomizations(), config.targets, color.code()));
 
       shift += delta;
     }, config.updateTime);
@@ -34,12 +48,17 @@ export function activate(context: vscode.ExtensionContext) {
     timer.stop();
   });
 
-  const resetCmd = vscode.commands.registerCommand('vscode-gaming.reset', () => {
+  const resetCmd = vscode.commands.registerCommand('vscode-gaming.reset', async () => {
     const timer = Timer.getInstance();
     timer.stop();
 
-    const globalConfig = vscode.workspace.getConfiguration();
-    globalConfig.update('workbench.colorCustomizations', originalCustomizations, true);
+    // Nothing was recorded, so there is nothing this extension is entitled to put back.
+    if (originalTargets.size === 0) {
+      return;
+    }
+
+    await updateColorCustomizations(TargetColors.restore(getColorCustomizations(), originalTargets));
+    originalTargets = new Map();
   });
 
   context.subscriptions.push(startCmd);

--- a/src/targetcolors.ts
+++ b/src/targetcolors.ts
@@ -1,0 +1,52 @@
+// The `workbench.colorCustomizations` object. Values are usually color codes, but the setting also
+// accepts theme-scoped blocks such as `"[Default Dark+]": { ... }`, so they are not narrowed here.
+export type ColorCustomizations = Record<string, unknown>;
+
+// The values that some targets held at a point in time. A target mapped to `undefined` was absent.
+export type TargetSnapshot = Map<string, unknown>;
+
+// Operations on the `gaming.targets` entries of a `workbench.colorCustomizations` object.
+//
+// Every operation copies the object and touches the target entries only, so customizations that
+// gaming mode never wrote to are always carried over untouched. This keeps the extension from
+// clobbering unrelated colors, and keeps the damage limited to the targets if a restore is missed.
+export class TargetColors {
+  private constructor() {
+    // noop
+  }
+
+  // Returns a copy of `customizations` with every target set to `color`.
+  public static apply(
+    customizations: ColorCustomizations | undefined,
+    targets: string[],
+    color: string,
+  ): ColorCustomizations {
+    const overrides = Object.fromEntries(targets.map((target) => [target, color]));
+
+    return { ...customizations, ...overrides };
+  }
+
+  // Records the values the targets currently hold, so that `restore` can put them back.
+  public static snapshot(customizations: ColorCustomizations | undefined, targets: string[]): TargetSnapshot {
+    return new Map(targets.map((target) => [target, customizations?.[target]]));
+  }
+
+  // Returns a copy of `customizations` with the snapshotted targets put back. Targets that were
+  // absent when the snapshot was taken are removed again instead of being set to `undefined`.
+  public static restore(
+    customizations: ColorCustomizations | undefined,
+    snapshot: TargetSnapshot,
+  ): ColorCustomizations {
+    const restored: ColorCustomizations = { ...customizations };
+
+    for (const [target, original] of snapshot) {
+      if (original === undefined) {
+        delete restored[target];
+      } else {
+        restored[target] = original;
+      }
+    }
+
+    return restored;
+  }
+}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -31,6 +31,34 @@ suite('Commands', () => {
     inspect: sinon.stub().returns({}),
   };
 
+  // Mock gaming configuration with default values
+  const mockGamingConfig: vscode.WorkspaceConfiguration = {
+    period: 10000,
+    updateTime: 50,
+    targets: ['editor.background'],
+    has: sinon.stub().returns(true),
+    inspect: sinon.stub().returns({}),
+    get: sinon.stub().callsFake((key: string) => {
+      if (key === 'period') return 10000;
+      if (key === 'updateTime') return 50;
+      if (key === 'targets') return ['editor.background'];
+
+      return undefined;
+    }),
+    update: sinon.stub().returns(Promise.resolve()),
+  };
+
+  // Stub getConfiguration to return the appropriate mock based on section
+  function stubGetConfiguration(configuration: vscode.WorkspaceConfiguration): sinon.SinonStub {
+    return sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
+      if (section === 'gaming') {
+        return mockGamingConfig;
+      }
+
+      return configuration;
+    });
+  }
+
   suiteSetup(async () => {
     clock = FakeTimers.install({ shouldClearNativeTimers: true });
 
@@ -51,44 +79,25 @@ suite('Commands', () => {
     // Mock workbench.colorCustomizations storage
     mockWorkbenchColorCustomizations = {};
 
-    // Mock gaming configuration with default values
-    const mockGamingConfig: vscode.WorkspaceConfiguration = {
-      period: 10000,
-      updateTime: 50,
-      targets: ['editor.background'],
-      has: sinon.stub().returns(true),
-      inspect: sinon.stub().returns({}),
-      get: sinon.stub().callsFake((key: string) => {
-        if (key === 'period') return 10000;
-        if (key === 'updateTime') return 50;
-        if (key === 'targets') return ['editor.background'];
-
-        return undefined;
-      }),
-      update: sinon.stub().returns(Promise.resolve()),
-    };
-
-    // Stub getConfiguration to return appropriate mock based on section
-    configStub = sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
-      if (section === 'gaming') {
-        return mockGamingConfig;
-      }
-
-      return mockConfiguration;
-    });
+    configStub = stubGetConfiguration(mockConfiguration);
   });
 
   teardown(async () => {
-    // Drop the snapshot the extension holds between commands, so that tests do not depend on
-    // whether the preceding one happened to end with a reset. Runs while the configuration is
-    // still stubbed, to keep it away from the real settings.
-    await vscode.commands.executeCommand('vscode-gaming.reset');
+    try {
+      // Drop the snapshot the extension holds between commands, so that tests do not depend on
+      // whether the preceding one happened to end with a reset. Runs while the configuration is
+      // still stubbed, to keep it away from the real settings.
+      await vscode.commands.executeCommand('vscode-gaming.reset');
+    } finally {
+      // Restore even if the reset above failed, so that one broken test does not leave every
+      // later one failing on an already wrapped getConfiguration
 
-    // Reset timer instance to ensure clean state between tests
-    Timer.resetInstance();
+      // Reset timer instance to ensure clean state between tests
+      Timer.resetInstance();
 
-    // Restore all stubs
-    configStub.restore();
+      // Restore all stubs
+      configStub.restore();
+    }
   });
 
   test('vscode-gaming.start', async () => {
@@ -135,9 +144,67 @@ suite('Commands', () => {
     // Execute reset command
     await vscode.commands.executeCommand('vscode-gaming.reset');
 
-    // Verify state after reset
+    // Verify state after reset. There was nothing to customize to begin with, so the setting is
+    // dropped rather than left behind as an empty block
     assert.equal(timer.isRunning(), false);
-    assert.deepEqual(mockWorkbenchColorCustomizations, {});
+    assert.equal(mockWorkbenchColorCustomizations, undefined);
+  });
+
+  test('vscode-gaming.reset waits for the write started by the animation', async () => {
+    let updateCount = 0;
+    let landAnimationUpdate: (() => void) | undefined;
+
+    // Swap in a configuration that holds the first write open, so that the write started by the
+    // animation is still in flight once reset runs
+    const heldConfiguration: vscode.WorkspaceConfiguration = {
+      ...mockConfiguration,
+      update: sinon.stub().callsFake((key: string, value: Record<string, string>) => {
+        updateCount += 1;
+        const land = () => {
+          if (key === 'workbench.colorCustomizations') {
+            mockWorkbenchColorCustomizations = value;
+          }
+        };
+
+        if (updateCount > 1) {
+          land();
+          return Promise.resolve();
+        }
+
+        return new Promise<void>((resolve) => {
+          landAnimationUpdate = () => {
+            land();
+            resolve();
+          };
+        });
+      }),
+    };
+
+    configStub.restore();
+    configStub = stubGetConfiguration(heldConfiguration);
+
+    try {
+      await vscode.commands.executeCommand('vscode-gaming.start');
+      clock.tick(50);
+
+      assert.equal(updateCount, 1);
+
+      const reset = vscode.commands.executeCommand('vscode-gaming.reset');
+      await Promise.resolve();
+
+      // Reset has not written anything on top of the in-flight write yet
+      assert.equal(updateCount, 1);
+
+      landAnimationUpdate?.();
+      await reset;
+
+      // The restore is the write that lands last
+      assert.equal(updateCount, 2);
+      assert.equal(mockWorkbenchColorCustomizations, undefined);
+    } finally {
+      // Never leave the held write pending, or teardown would wait on it forever
+      landAnimationUpdate?.();
+    }
   });
 
   test('vscode-gaming.start keeps customizations that are not targets', async () => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -11,7 +11,7 @@ suite('Commands', () => {
   let configStub: sinon.SinonStub;
 
   // Mock configuration
-  let mockWorkbenchColorCustomizations: Record<string, string>;
+  let mockWorkbenchColorCustomizations: Record<string, string> | undefined;
   const mockConfiguration: vscode.WorkspaceConfiguration = {
     get: sinon.stub().callsFake((key: string) => {
       if (key === 'workbench.colorCustomizations') {
@@ -20,7 +20,7 @@ suite('Commands', () => {
 
       return undefined;
     }),
-    update: sinon.stub().callsFake((key: string, value: Record<string, string>) => {
+    update: sinon.stub().callsFake((key: string, value: Record<string, string> | undefined) => {
       if (key === 'workbench.colorCustomizations') {
         mockWorkbenchColorCustomizations = value;
       }
@@ -114,7 +114,7 @@ suite('Commands', () => {
     // Verify state after start
     assert.equal(timer.isRunning(), true);
     assert.notDeepEqual(mockWorkbenchColorCustomizations, {});
-    assert.ok(mockWorkbenchColorCustomizations['editor.background']);
+    assert.ok(mockWorkbenchColorCustomizations?.['editor.background']);
   });
 
   test('vscode-gaming.stop', async () => {
@@ -158,7 +158,7 @@ suite('Commands', () => {
     // animation is still in flight once reset runs
     const heldConfiguration: vscode.WorkspaceConfiguration = {
       ...mockConfiguration,
-      update: sinon.stub().callsFake((key: string, value: Record<string, string>) => {
+      update: sinon.stub().callsFake((key: string, value: Record<string, string> | undefined) => {
         updateCount += 1;
         const land = () => {
           if (key === 'workbench.colorCustomizations') {
@@ -216,9 +216,9 @@ suite('Commands', () => {
     clock.tick(50);
 
     // Only the target is overwritten, while gaming mode is still running
-    assert.ok(mockWorkbenchColorCustomizations['editor.background']);
-    assert.equal(mockWorkbenchColorCustomizations['panel.background'], '#123456');
-    assert.equal(mockWorkbenchColorCustomizations['statusBar.background'], '#654321');
+    assert.ok(mockWorkbenchColorCustomizations?.['editor.background']);
+    assert.equal(mockWorkbenchColorCustomizations?.['panel.background'], '#123456');
+    assert.equal(mockWorkbenchColorCustomizations?.['statusBar.background'], '#654321');
   });
 
   test('vscode-gaming.reset restores the previous value of a target', async () => {
@@ -230,7 +230,7 @@ suite('Commands', () => {
     await vscode.commands.executeCommand('vscode-gaming.start');
     clock.tick(50);
 
-    assert.notEqual(mockWorkbenchColorCustomizations['editor.background'], '#123456');
+    assert.notEqual(mockWorkbenchColorCustomizations?.['editor.background'], '#123456');
 
     // Reset should restore the value the target had before
     await vscode.commands.executeCommand('vscode-gaming.reset');

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -78,7 +78,12 @@ suite('Commands', () => {
     });
   });
 
-  teardown(() => {
+  teardown(async () => {
+    // Drop the snapshot the extension holds between commands, so that tests do not depend on
+    // whether the preceding one happened to end with a reset. Runs while the configuration is
+    // still stubbed, to keep it away from the real settings.
+    await vscode.commands.executeCommand('vscode-gaming.reset');
+
     // Reset timer instance to ensure clean state between tests
     Timer.resetInstance();
 
@@ -133,6 +138,62 @@ suite('Commands', () => {
     // Verify state after reset
     assert.equal(timer.isRunning(), false);
     assert.deepEqual(mockWorkbenchColorCustomizations, {});
+  });
+
+  test('vscode-gaming.start keeps customizations that are not targets', async () => {
+    // Set initial customizations
+    mockWorkbenchColorCustomizations = { 'panel.background': '#123456', 'statusBar.background': '#654321' };
+
+    // Start gaming mode
+    await vscode.commands.executeCommand('vscode-gaming.start');
+    clock.tick(50);
+
+    // Only the target is overwritten, while gaming mode is still running
+    assert.ok(mockWorkbenchColorCustomizations['editor.background']);
+    assert.equal(mockWorkbenchColorCustomizations['panel.background'], '#123456');
+    assert.equal(mockWorkbenchColorCustomizations['statusBar.background'], '#654321');
+  });
+
+  test('vscode-gaming.reset restores the previous value of a target', async () => {
+    // Set initial customizations
+    const originalCustomizations = { 'editor.background': '#123456' };
+    mockWorkbenchColorCustomizations = originalCustomizations;
+
+    // Start gaming mode
+    await vscode.commands.executeCommand('vscode-gaming.start');
+    clock.tick(50);
+
+    assert.notEqual(mockWorkbenchColorCustomizations['editor.background'], '#123456');
+
+    // Reset should restore the value the target had before
+    await vscode.commands.executeCommand('vscode-gaming.reset');
+
+    assert.deepEqual(mockWorkbenchColorCustomizations, originalCustomizations);
+  });
+
+  test('vscode-gaming.reset keeps customizations changed while gaming mode was running', async () => {
+    // Start gaming mode
+    await vscode.commands.executeCommand('vscode-gaming.start');
+    clock.tick(50);
+
+    // The user edits an unrelated customization while gaming mode is running
+    mockWorkbenchColorCustomizations = { ...mockWorkbenchColorCustomizations, 'panel.background': '#123456' };
+
+    // Reset should leave that edit alone
+    await vscode.commands.executeCommand('vscode-gaming.reset');
+
+    assert.deepEqual(mockWorkbenchColorCustomizations, { 'panel.background': '#123456' });
+  });
+
+  test('vscode-gaming.reset without gaming mode leaves customizations alone', async () => {
+    // Set initial customizations, including one that happens to be a target
+    const originalCustomizations = { 'editor.background': '#123456', 'panel.background': '#654321' };
+    mockWorkbenchColorCustomizations = originalCustomizations;
+
+    // Reset without ever having started gaming mode
+    await vscode.commands.executeCommand('vscode-gaming.reset');
+
+    assert.deepEqual(mockWorkbenchColorCustomizations, originalCustomizations);
   });
 
   test('vscode-gaming.start preserves original customizations', async () => {

--- a/src/test/targetcolors.test.ts
+++ b/src/test/targetcolors.test.ts
@@ -1,0 +1,122 @@
+import * as assert from 'node:assert';
+
+import { TargetColors } from '../targetcolors';
+
+suite('TargetColors', () => {
+  suite('.apply', () => {
+    test('sets every target to the given color', () => {
+      const customizations = { 'editor.background': '#000000' };
+      const applied = TargetColors.apply(customizations, ['editor.background', 'sideBar.background'], '#ff0000');
+
+      assert.deepEqual(applied, { 'editor.background': '#ff0000', 'sideBar.background': '#ff0000' });
+    });
+
+    test('keeps entries that are not targets', () => {
+      const customizations = { 'panel.background': '#123456', 'statusBar.background': '#654321' };
+      const applied = TargetColors.apply(customizations, ['editor.background'], '#ff0000');
+
+      assert.deepEqual(applied, {
+        'panel.background': '#123456',
+        'statusBar.background': '#654321',
+        'editor.background': '#ff0000',
+      });
+    });
+
+    test('does not mutate the given customizations', () => {
+      const customizations = { 'panel.background': '#123456' };
+      TargetColors.apply(customizations, ['editor.background'], '#ff0000');
+
+      assert.deepEqual(customizations, { 'panel.background': '#123456' });
+    });
+
+    test('handles missing customizations', () => {
+      assert.deepEqual(TargetColors.apply(undefined, ['editor.background'], '#ff0000'), {
+        'editor.background': '#ff0000',
+      });
+    });
+
+    test('handles no targets', () => {
+      const customizations = { 'panel.background': '#123456' };
+
+      assert.deepEqual(TargetColors.apply(customizations, [], '#ff0000'), customizations);
+    });
+  });
+
+  suite('.snapshot', () => {
+    test('records the value of each target', () => {
+      const customizations = { 'editor.background': '#123456', 'panel.background': '#654321' };
+      const snapshot = TargetColors.snapshot(customizations, ['editor.background']);
+
+      assert.deepEqual(snapshot, new Map([['editor.background', '#123456']]));
+    });
+
+    test('records an absent target as undefined', () => {
+      const snapshot = TargetColors.snapshot({ 'panel.background': '#654321' }, ['editor.background']);
+
+      assert.deepEqual(snapshot, new Map([['editor.background', undefined]]));
+    });
+
+    test('handles missing customizations', () => {
+      const snapshot = TargetColors.snapshot(undefined, ['editor.background']);
+
+      assert.deepEqual(snapshot, new Map([['editor.background', undefined]]));
+    });
+  });
+
+  suite('.restore', () => {
+    test('puts back the snapshotted values', () => {
+      const snapshot = TargetColors.snapshot({ 'editor.background': '#123456' }, ['editor.background']);
+      const restored = TargetColors.restore({ 'editor.background': '#ff0000' }, snapshot);
+
+      assert.deepEqual(restored, { 'editor.background': '#123456' });
+    });
+
+    test('removes targets that were absent when the snapshot was taken', () => {
+      const snapshot = TargetColors.snapshot({}, ['editor.background']);
+      const restored = TargetColors.restore({ 'editor.background': '#ff0000' }, snapshot);
+
+      assert.deepEqual(restored, {});
+      assert.equal('editor.background' in restored, false);
+    });
+
+    test('keeps entries that are not targets', () => {
+      const snapshot = TargetColors.snapshot({ 'panel.background': '#123456' }, ['editor.background']);
+      const restored = TargetColors.restore(
+        { 'panel.background': '#123456', 'statusBar.background': '#abcdef', 'editor.background': '#ff0000' },
+        snapshot,
+      );
+
+      assert.deepEqual(restored, { 'panel.background': '#123456', 'statusBar.background': '#abcdef' });
+    });
+
+    test('keeps entries the user changed while gaming mode was running', () => {
+      const snapshot = TargetColors.snapshot({ 'panel.background': '#123456' }, ['editor.background']);
+      const restored = TargetColors.restore(
+        { 'panel.background': '#ffffff', 'editor.background': '#ff0000' },
+        snapshot,
+      );
+
+      assert.deepEqual(restored, { 'panel.background': '#ffffff' });
+    });
+
+    test('does not mutate the given customizations', () => {
+      const snapshot = TargetColors.snapshot({}, ['editor.background']);
+      const customizations = { 'editor.background': '#ff0000' };
+      TargetColors.restore(customizations, snapshot);
+
+      assert.deepEqual(customizations, { 'editor.background': '#ff0000' });
+    });
+
+    test('handles missing customizations', () => {
+      const snapshot = TargetColors.snapshot({ 'editor.background': '#123456' }, ['editor.background']);
+
+      assert.deepEqual(TargetColors.restore(undefined, snapshot), { 'editor.background': '#123456' });
+    });
+
+    test('handles an empty snapshot', () => {
+      const customizations = { 'panel.background': '#123456' };
+
+      assert.deepEqual(TargetColors.restore(customizations, new Map()), customizations);
+    });
+  });
+});


### PR DESCRIPTION
Closes #29.

## What changed

Gaming mode no longer replaces the whole `workbench.colorCustomizations` object. It now merges into it and touches the `gaming.targets` entries only, in both directions:

- **Each animation tick** copies the current customizations and overrides only the targets.
- **`reset`** puts back the values those targets held before gaming mode started, deleting the ones that were absent, and carries every other entry over untouched.

The blast radius of the extension goes from "all of `workbench.colorCustomizations`" down to "the keys listed in `gaming.targets`". A user who never manages to run `reset` now loses `editor.background` instead of their entire color customization block.

## Notable details

- **`reset` is a no-op when nothing was recorded.** It used to write back a snapshot taken at activation time, which meant running `reset` without ever starting gaming mode rewrote the setting for no reason. There is nothing this extension is entitled to put back in that state, so it now leaves the setting alone.
- **The configuration is re-read on every access.** `WorkspaceConfiguration` is a snapshot rather than a live view, so the object obtained once in `start` would have gone stale and the merge would have dropped anything written after it.
- **`gaming.targets` is captured when the animation starts**, not re-read per tick, so the set of keys the animation writes always matches the set recorded for the restore.
- Restore values are kept in a `Map` where a target mapped to `undefined` means "was absent", which is what lets `reset` tell "put `#123456` back" apart from "remove this key again".

## Tests

`TargetColors` is a plain module with no `vscode` dependency, so the merge and restore rules are unit-tested directly (16 cases: unrelated entries preserved, absent targets removed rather than set to `undefined`, inputs never mutated, missing customizations, empty target list, empty snapshot).

Four cases were added to the command tests, covering the reported behavior end to end:

- unrelated customizations survive while gaming mode is running
- `reset` restores the previous value of a target that the user had customized
- `reset` keeps customizations the user changed while gaming mode was running
- `reset` without gaming mode leaves customizations alone

Teardown now clears the extension's snapshot between cases, so these do not depend on whether the preceding test happened to end with a `reset`.

## Out of scope

- Restoring the original colors after a VS Code restart is #30. This PR does not make that case work; it only makes it survivable, since the colors the extension never wrote are no longer collateral damage.
- Also pre-existing on `main` and left to #30: `deactivate` only stops the timer, so quitting VS Code during gaming mode leaves the gaming color in `settings.json`. Restoring from `deactivate` is not reliable, since there is no guarantee an asynchronous settings write flushes during shutdown, which is why #30 proposes restoring at activation time instead.
- Related, and pre-existing on `main`: `stop` followed by `start` re-reads the originals from customizations that already hold gaming colors, so a later `reset` puts a gaming color back into the target. Unrelated entries are unaffected. This belongs with the persistence work in #30 rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

