### PR TITLE
docs: follow Keep a Changelog in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,44 @@
-# Change Log
+# Changelog
 
 All notable changes to the "vscode-gaming" extension will be documented in this file.
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
-* Fixed gaming mode overwriting color customizations outside of `gaming.targets`
-* Fixed reset changing `workbench.colorCustomizations` when gaming mode had never been started
-* Fixed the original colors being unrecoverable after quitting VS Code with gaming mode running
-* The original colors are now put back automatically on the next startup
-* Fixed reset restoring a gaming color after gaming mode had been stopped and started again
+### Added
 
-## 0.1.0
+- The original colors are now restored automatically on the next startup after quitting VS Code with gaming mode running
 
-* Added reset command
-* Added `gaming.targets` option instead of `gaming.target`
-* Improved color reproducibility
+### Fixed
 
-## 0.0.1
+- Gaming mode no longer overwrites color customizations outside of `gaming.targets`
+- Reset no longer changes `workbench.colorCustomizations` when gaming mode has never been started
+- The original colors are no longer unrecoverable after quitting VS Code with gaming mode running
+- Reset no longer restores a gaming color after gaming mode has been stopped and started again
 
-* Initial release
+## [0.1.0] - 2023-12-26
+
+### Added
+
+- Reset command
+- `gaming.targets` setting, which replaces `gaming.target`
+
+### Changed
+
+- Improved color reproducibility
+
+### Removed
+
+- `gaming.target` setting, replaced by `gaming.targets`
+
+## [0.0.1] - 2023-12-24
+
+### Added
+
+- Initial release
+
+[Unreleased]: https://github.com/akiomik/vscode-gaming/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/akiomik/vscode-gaming/compare/v0.0.1...v0.1.0
+[0.0.1]: https://github.com/akiomik/vscode-gaming/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -28,15 +28,7 @@ This extension contributes the following settings:
 
 ## Release Notes
 
-### 0.1.0
-
-* Added reset command
-* Added `gaming.targets` option instead of `gaming.target`
-* Improved color reproducibility
-
-### 0.0.1
-
-* Initial release
+See [CHANGELOG.md](CHANGELOG.md).
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Rewrite `CHANGELOG.md` in the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 1.1.0 format
- Remove the duplicated "Release Notes" list from `README.md` and link to `CHANGELOG.md` instead

## Details

`CHANGELOG.md` linked to Keep a Changelog but did not follow it. It now does:

- `## [x.y.z] - YYYY-MM-DD` headings, with dates taken from the `v0.0.1` / `v0.1.0` git tags (2023-12-24 / 2023-12-26)
- Entries grouped under `### Added` / `### Changed` / `### Fixed` / `### Removed`
- `-` bullets and compare links at the bottom of the file
- The 0.1.0 removal of the `gaming.target` setting is now stated explicitly under `### Removed`; it no longer exists in `package.json` or the source
- Unreleased "Fixed ..." entries reworded to describe the resulting behavior

`README.md` kept a copy of the released notes that had to be updated in two places, so it now points to `CHANGELOG.md`.

Docs only — no behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)