### PR TITLE
docs: replace the retired Marketplace version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vscode-gaming
 
-[![Visual Studio Marketplace Version (including pre-releases)](https://img.shields.io/visual-studio-marketplace/v/omi.vscode-gaming)](https://marketplace.visualstudio.com/items?itemName=omi.vscode-gaming)
+[![Version](https://img.shields.io/github/v/release/akiomik/vscode-gaming?sort=semver&label=version)](https://marketplace.visualstudio.com/items?itemName=omi.vscode-gaming)
 [![Node.js Test](https://github.com/akiomik/vscode-gaming/actions/workflows/test.yml/badge.svg)](https://github.com/akiomik/vscode-gaming/actions/workflows/test.yml)
 
 ![banner](images/github-banner.png)


### PR DESCRIPTION
## Problem

The Visual Studio Marketplace version badge in `README.md` renders as `retired badge`:

```
aria-label="visual-studio-marketplace: retired badge"
```

This is not specific to this extension. shields.io has retired the entire `visual-studio-marketplace/*` service: every badge type (version, installs, rating) returns the same placeholder for every extension, and the documentation page for the badge now 404s.

The cause is that the Marketplace exposes no publicly documented API for third-party metadata retrieval, and the undocumented endpoints shields relied on caused frequent rate-limiting at their scale. shields has asked Microsoft for an official public endpoint in [microsoft/vsmarketplace#1776](https://github.com/microsoft/vsmarketplace/issues/1776), but that issue is still open and unanswered, so the badge is unlikely to come back soon.

See also [badges/shields#11796](https://github.com/badges/shields/issues/11796).

## Change

Source the version from GitHub Releases, which is a documented and stable API, while keeping the link pointing at the Marketplace page so the badge still leads to the install page.

| | Before | After |
|---|---|---|
| Data source | VS Marketplace (retired) | GitHub Releases |
| Rendering | `retired badge` | `version \| v0.1.0` |
| Link target | Marketplace page | Marketplace page (unchanged) |

## Notes on the parameters

- `label=version` — the default label is `release`. Since the data comes from GitHub Releases while the link goes to the Marketplace, a neutral `version` avoids claiming a data source the badge does not actually read from.
- `sort=semver` — the default picks the most recent release by date. Sorting by semver keeps the highest version displayed even if a patch for an older version is published later.

A dedicated badge service such as `vsmarketplacebadges.dev` was considered and does currently work, but it depends on the same undocumented endpoints that caused the shields retirement, so it carries the same long-term risk.

This badge does depend on releases being tagged. If a version is ever published to the Marketplace without a corresponding GitHub Release, the badge will lag behind.

`CHANGELOG.md` is intentionally not updated: this changes documentation only, not extension behavior.

## Verification

The badge URL returns `version: v0.1.0`, matching both `"version": "0.1.0"` in `package.json` and the latest release `v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)