### PR TITLE
ci: type-check TypeScript in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,4 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint:ci
+      - run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "publish": "vsce publish",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
+    "typecheck": "tsc --noEmit -p ./",
     "pretest": "npm run compile",
     "test": "vscode-test",
     "format": "biome format --write .",


### PR DESCRIPTION
## Problem

The CI workflow (`.github/workflows/ci.yml`) only runs `biome ci`, which does not perform type checking. Type errors were therefore invisible to it.

They were caught only by the test workflow, where `tsc` runs as an implicit `pretest` step before `vscode-test`. That has two downsides:

- A pure type error is reported as a *test* failure, so the logs have to be read to tell a build break from a genuine test break.
- The job in `ci.yml` is named `build` but never built anything.

## Change

- Add a `typecheck` script to `package.json` that runs `tsc --noEmit -p ./`.
- Run it in the CI workflow after `lint:ci`.

`--noEmit` is used so the check stays a pure type check and does not race with the compile step the test workflow performs.

## Verification

Both commands pass locally on this branch:

- `npm run typecheck` — exits 0
- `npm run lint:ci` — checked 20 files, no fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)