### PR TITLE
ci: install with npm ci in the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         node-version-file: '.node-version'
         cache: npm
-    - run: npm install
+    - run: npm ci
     - run: xvfb-run -a npm test
       if: runner.os == 'Linux'
     - run: npm test


### PR DESCRIPTION
## Problem

The test workflow installed dependencies with `npm install`, while the CI and publish workflows both use `npm ci`.

`npm install` is free to resolve versions that differ from `package-lock.json` and to rewrite the lockfile in place. Tests could therefore run against a dependency tree that nobody else ever gets, and the one workflow that actually exercises the extension was the least reproducible of the three.

## Change

Use `npm ci` in `.github/workflows/test.yml`, matching the other two workflows.

## Verification

`npm ci --dry-run` exits 0 on this branch with no `EUSAGE` / out-of-sync errors, so the lockfile and `package.json` agree and the stricter install will succeed.

The test suite itself was not run locally — it needs a VS Code instance — but this change only affects how dependencies are installed, not what the tests do.

## Note

Both `npm install` and `npm ci` trigger the deprecated `prepublish` script, so this does not change which lifecycle scripts run during the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)