### PR TITLE
chore: replace the prepublish script with an explicit package script

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "prepublish": "vsce package",
+    "package": "vsce package",
     "publish": "vsce publish",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",


### PR DESCRIPTION
## Problem

`package.json` defined `"prepublish": "vsce package"`. npm still runs the deprecated `prepublish` script on a plain `npm install`, so **every dependency install in every workflow also built a full extension bundle** that nothing then consumed. Verified on npm 11.16.0:

| command | scripts npm runs |
|---|---|
| `npm install` / `npm ci` | `prepublish`, `prepare` |
| `npm run publish` | `prepublish`, `publish` |
| `npm pack` | `prepack`, `prepare` |

It was redundant on the release path as well. `vsce publish` with no `--packagePath` packages the extension itself (`publish.js:124-128`), and that internal pack runs `vscode:prepublish` (`package.js:1487`), so compilation still happens.

`prepack` was considered first, but the table above shows `npm run publish` does not trigger it, and nothing in this repository runs `npm pack` — the script would simply never execute again.

## Change

Rename `prepublish` to `package`. Building a bundle becomes an explicit `npm run package` instead of a side effect of installing dependencies.

## Verification

- `npm ci --dry-run` — exits 0, no packaging occurs and no bundle is produced (previously one was built every time)
- `npm run package` — exits 0, still runs `vscode:prepublish` and produces the bundle
- `npm run lint:ci` — checked 20 files, no fixes applied
- `npm run typecheck` — exits 0

`vsce publish` itself was not executed, since that would publish to the Marketplace. Its packaging behaviour was confirmed by reading the source, cited above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)