### PR TITLE
ci: name each workflow job after what it does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: ['main']
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: ['main']
 
 jobs:
-  build:
+  test:
     strategy:
       matrix:
         # NOTE: Disabled on windows due to different singleton behavior


### PR DESCRIPTION
## Problem

All three workflows named their only job `build`:

| workflow | job | what it actually runs |
|---|---|---|
| `ci.yml` | `build` | `biome ci` + `tsc --noEmit` |
| `test.yml` | `build` | `vscode-test` |
| `publish.yml` | `build` | `vsce publish` |

None of them builds anything as its purpose, so every status check was reported under a name that said nothing about what ran. A failure in `build (ubuntu-latest)` gave no hint whether tests broke or something else did.

## Change

Rename the jobs to `check`, `test` and `publish`.

## Required follow-up on branch protection

This changes the reported status check names. The protection rule for `main` currently requires:

- `build`
- `build (macos-latest)`
- `build (ubuntu-latest)`

which must become:

- `check`
- `test (macos-latest)`
- `test (ubuntu-latest)`

The old names will never be reported again, so the rule has to be updated or every later pull request will wait forever on a check that cannot arrive. The open Dependabot pull requests will pick up the new names once they rebase onto `main`, which they need to do anyway because the rule requires branches to be up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)