### PR TITLE
chore: declare the global type packages explicitly in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "outDir": "out",
     "lib": ["ES2022"],
+    "types": ["node", "mocha"] /* TypeScript 7 no longer includes every @types package automatically */,
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */


### PR DESCRIPTION
## Summary

TypeScript 7 no longer pulls in every package under `node_modules/@types` automatically. Without an explicit `types` list, the globals from `@types/node` and `@types/mocha` go missing and `npm run typecheck` fails:

```
src/extension.ts(15,5): error TS2584: Cannot find name 'console'.
src/test/color.test.ts(5,1): error TS2593: Cannot find name 'suite'.
src/timer.ts(3,20): error TS2503: Cannot find namespace 'NodeJS'.
```

Listing the two packages in `types` restores those globals. TypeScript 5 already resolves them the same way, so this is a no-op today.

## Why now

This unblocks #41 (typescript 5.3.3 -> 7.0.2), which currently fails CI for exactly this reason. #42 (`@types/node` 22.x -> 26.x) is blocked behind #41 in turn, because the types it ships reference `IteratorObject` and `BuiltinIteratorReturn`, which were only introduced in TypeScript 5.6.

## Test plan

- `npm run lint:ci` passes
- `npm run typecheck` passes on TypeScript 5.3.3 (this branch)
- Verified locally that #41 rebased onto this change passes `npm run typecheck` and `npm test` (57 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)