### PR TITLE
test: give the command suite room for the real globalState

### DIFF
--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -7,7 +7,13 @@ import { Timer } from '../timer';
 // What each command does is covered by the GamingMode tests. These check that the commands are
 // registered and wired to it, against the real extension host, so they run on real timers: the
 // commands write to the real globalState, which fake timers would keep from ever settling.
-suite('Commands', () => {
+suite('Commands', function () {
+  // Every command here waits on the real globalState, which VS Code flushes to disk on its own
+  // schedule, so a step that usually takes milliseconds can occasionally take seconds. The mocha
+  // default leaves no room for that, and none of these tests are meant to assert how long anything
+  // takes, so allow far more than they should ever need.
+  this.timeout(30000);
+
   let configStub: sinon.SinonStub;
   let customizations: Record<string, unknown> | undefined;
 


### PR DESCRIPTION
## Problem

The `Commands` suite in `src/test/extension.test.ts` fails intermittently:

```
1) Commands
     vscode-gaming.reset:
   Error: Timeout of 2000ms exceeded.
```

Unlike the other suites, this one deliberately runs on real timers against the real extension host, so every command it invokes ends up awaiting a `globalState` write (`GamingState#save` / `#clear`). VS Code flushes that storage on its own schedule, which the test cannot control.

Measured locally across repeated runs, `vscode-gaming.reset` alone ranges from **65ms to 1206ms** — the mocha default of 2000ms leaves almost no headroom, and the `suiteSetup` hook already spends 1500ms of it waiting out the activation-time restore.

## Change

Raise the timeout for this suite only, to 30s. The other suites use fake timers and are unaffected, so a hang there still fails fast.

None of these tests assert how long anything takes — they check that the commands are registered and wired to `GamingMode` — so a generous limit costs nothing.

## Test plan

- `npm run lint:ci` passes
- `npm run typecheck` passes
- `npm test` run 4 times in a row: 57 passing each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)