### PR TITLE
build: modernize the TypeScript configuration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -7,9 +7,15 @@ export class Config {
 
   constructor() {
     const gamingConfig = vscode.workspace.getConfiguration('gaming');
-    this.period = gamingConfig.period;
-    this.updateTime = gamingConfig.updateTime;
-    this.targets = gamingConfig.targets;
+
+    // Reading a setting as a property goes through the index signature of `WorkspaceConfiguration`
+    // and is typed `any`, so nothing here would be checked. `get` is typed by what it is given as
+    // the fallback instead. The fallbacks repeat the defaults contributed in package.json, which
+    // is what a read answers with unless the user has set the value; `get` has no way to know that
+    // a contributed default exists, and the `Config` tests pin them to those defaults.
+    this.period = gamingConfig.get('period', 10000);
+    this.updateTime = gamingConfig.get('updateTime', 50);
+    this.targets = gamingConfig.get('targets', ['editor.background']);
   }
 
   delta(): number {

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -3,6 +3,17 @@ import * as assert from 'node:assert';
 import { Config } from '../config';
 
 suite('Config', () => {
+  // Read against the real configuration, with nothing set: what comes back is what package.json
+  // contributes. `Config` repeats those defaults as the fallbacks of its `get` calls, so this
+  // fails if the two ever drift apart.
+  test('reads the defaults contributed in package.json', () => {
+    const config = new Config();
+
+    assert.equal(config.period, 10000);
+    assert.equal(config.updateTime, 50);
+    assert.deepEqual(config.targets, ['editor.background']);
+  });
+
   test('#delta', () => {
     const config = new Config();
     assert.equal(config.delta(), 0.031415926535897934);

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -56,10 +56,17 @@ suite('Commands', function () {
 
     configStub = sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
       if (section === 'gaming') {
-        return {
+        const gaming: Record<string, unknown> = {
           period: 10000,
           updateTime: UPDATE_TIME,
           targets: ['editor.background'],
+        };
+
+        return {
+          get: <T>(key: string, defaultValue?: T) => (gaming[key] as T | undefined) ?? defaultValue,
+          update: () => Promise.resolve(),
+          has: (key: string) => key in gaming,
+          inspect: () => ({}),
         } as unknown as vscode.WorkspaceConfiguration;
       }
 

--- a/src/test/gamingmode.test.ts
+++ b/src/test/gamingmode.test.ts
@@ -87,7 +87,14 @@ suite('GamingMode', () => {
 
     configStub = sinon.stub(vscode.workspace, 'getConfiguration').callsFake((section?: string) => {
       if (section === 'gaming') {
-        return { period: 10000, updateTime, targets } as unknown as vscode.WorkspaceConfiguration;
+        const gaming: Record<string, unknown> = { period: 10000, updateTime, targets };
+
+        return {
+          get: <T>(key: string, defaultValue?: T) => (gaming[key] as T | undefined) ?? defaultValue,
+          update: () => Promise.resolve(),
+          has: (key: string) => key in gaming,
+          inspect: () => ({}),
+        } as unknown as vscode.WorkspaceConfiguration;
       }
 
       return workbenchConfiguration;

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -1,6 +1,6 @@
 export class Timer {
-  private static instance?: Timer;
-  private _timer?: NodeJS.Timeout;
+  private static instance: Timer | undefined;
+  private _timer: NodeJS.Timeout | undefined;
 
   static getInstance() {
     if (!Timer.instance) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": true,
     "exactOptionalPropertyTypes": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,34 @@
 {
   "compilerOptions": {
-    "module": "Node16",
+    /* Language and environment: the extension host of VS Code ^1.85.0 runs on Node.js 18 */
     "target": "ES2022",
-    "outDir": "out",
     "lib": ["ES2022"],
-    "types": ["node", "mocha"] /* TypeScript 7 no longer includes every @types package automatically */,
-    "sourceMap": true,
+
+    /* Modules: the extension host loads `main` as CommonJS, which is what `Node16` emits here */
+    "module": "Node16",
     "rootDir": "src",
-    "strict": true /* enable all strict type-checking options */
-    /* Additional Checks */
-    // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-    // "noUnusedParameters": true,  /* Report errors on unused parameters. */
-  }
+    "types": ["node", "mocha"] /* TypeScript 7 no longer includes every @types package automatically */,
+
+    /* Emit */
+    "outDir": "out",
+    "sourceMap": true,
+    "noEmitOnError": true /* Keep a failed compile from leaving half-updated output in `out` */,
+
+    /* Type checking */
+    "strict": true /* enable all strict type-checking options */,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+
+    /* Interop constraints */
+    "isolatedModules": true,
+    "erasableSyntaxOnly": true /* Keep to syntax that a type-stripping runtime can also run */
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
Modernizes `tsconfig.json`, and fixes the one place where the stricter checking found something real.

## Compiler options

Enables the additional checks that were left commented out at the bottom of the file, plus the ones the sources already satisfy so that they cannot regress: `noUncheckedIndexedAccess`, `noImplicitOverride`, `noUnusedLocals`, `exactOptionalPropertyTypes`, `isolatedModules`, `erasableSyntaxOnly`, `noEmitOnError`, and `allowUnreachableCode` / `allowUnusedLabels` as errors rather than warnings.

The rest is reorganized by purpose, and the compiled set is made explicit with `include` instead of relying on the implicit scan of the project root.

Two things stay as they are, on purpose:

- **`target`/`lib` at ES2022 and `module` at Node16.** The extension host of the supported VS Code (`engines.vscode: ^1.85.0`) runs on Node.js 18 and loads the extension as CommonJS. ES2023 would make `toSorted` and friends type-check against a runtime that has no such thing.
- **`verbatimModuleSyntax` off.** Every file fails `TS1295` under it while the output is CommonJS; adopting it means moving the extension to ESM first.

`skipLibCheck` is also left off, since the lib check currently passes and turning it on only removes coverage.

## The `any` this turned up

`exactOptionalPropertyTypes` rejected assigning `undefined` to the two optional fields of `Timer`, which are now declared `| undefined`. That one is mechanical.

The real finding is in `Config`. Reading a setting as a property of `WorkspaceConfiguration` goes through its index signature and is typed `any`, so all three fields were assigned with no checking whatsoever — a setting holding something other than what package.json contributes reached `delta()` and the animation as a `number` or a `string[]` that it never was.

They are read with `get()` now, which is typed by the fallback it is given, and `noPropertyAccessFromIndexSignature` keeps a later read from quietly going back to the unchecked form.

The fallbacks repeat the defaults contributed in package.json, because `get()` has no way to know a contributed default exists. To keep the two from drifting apart unnoticed, a test pins them against the real configuration.

This is also why the tests needed touching: the gaming half of the `getConfiguration` stubs was a plain object of values, which only worked because property access reaches into anything. It answers `get()` now, like the workbench half already did.

## Checks

`npm run lint:ci`, `npm run typecheck`, `npm run compile`, and `npm test` (58 passing) all pass. Both commits type-check on their own, so the history stays bisectable. The two Biome infos are pre-existing and come from the schema version in `biome.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)