### PR TITLE
fix: match @types/vscode to the supported VS Code, and package in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # `@types/vscode` is the API of the oldest VS Code the extension supports, which is what
+      # `engines.vscode` declares, so the two only ever move together. On its own an update makes
+      # the extension unpackageable, and would offer APIs that the supported VS Code has not got.
+      - dependency-name: "@types/vscode"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,19 @@ jobs:
       - run: npm ci
       - run: npm run lint:ci
       - run: npm run typecheck
+
+  # Packaging is what the release workflow does before it publishes, and it validates things the
+  # other jobs never look at, such as `engines.vscode` agreeing with the version of `@types/vscode`.
+  # Run it on every change, so that a release is not the place where such a mismatch turns up.
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Use Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run package

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/node": "26.x",
         "@types/sinon": "^22.0.0",
         "@types/sinonjs__fake-timers": "^15.0.1",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "^1.85.0",
         "@vscode/test-cli": "^0.0.15",
         "@vscode/test-electron": "^3.1.0",
         "@vscode/vsce": "^3.9.2",
@@ -1007,9 +1007,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@types/node": "26.x",
     "@types/sinon": "^22.0.0",
     "@types/sinonjs__fake-timers": "^15.0.1",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "^1.85.0",
     "@vscode/test-cli": "^0.0.15",
     "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.9.2",


### PR DESCRIPTION
`npm run package` currently fails on `main`, which means a release cannot be cut:

```
ERROR  @types/vscode ^1.125.0 greater than engines.vscode ^1.85.0.
       Either upgrade engines.vscode or use an older @types/vscode version
```

`@types/vscode` is the API of the oldest VS Code the extension supports, which is what `engines.vscode` declares, so the two only ever move together. They agreed at `^1.85.0` from 2023 until an update to `1.125.0` landed on its own.

## The fix

The types go back to `^1.85.0`, rather than `engines` going up.

Raising the floor to 1.125 would drop every VS Code below it for an extension that asks for nothing newer than commands, `workspace.getConfiguration` and a `Memento`. That is a decision about who the extension supports, worth making deliberately — and one to revisit alongside ESM, which needs 1.100 at runtime and 1.119 for the test harness — not a way out of a mismatch.

Dependabot is told to leave `@types/vscode` alone, since an update to it on its own can only ever reintroduce this.

## Why nothing caught it

Packaging was validated nowhere. CI lints and type-checks, the test workflow runs the suite, and `vsce` only ever ran when a release was published — so the one thing that fails is the one thing that had never been run.

Neither of the existing jobs could have caught it either: the sources only use APIs that have been there for years, so the type check passes against either version of the types, and the tests run against whatever VS Code the harness downloads rather than against the declared minimum.

So this adds a `package` job to the CI workflow, running on every push and pull request. Confirmed it does catch this: with the types put back to `^1.125.0`, `npm run package` exits 1.

## Checks

`npm run lint:ci`, `npm run typecheck`, `npm test` (58 passing) and `npm run package` all pass, with the type check now running against the 1.85 API surface. The lock change is limited to `@types/vscode`. The two Biome infos are pre-existing and come from the schema version in `biome.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)