### PR TITLE
chore(deps-dev): resolve all npm audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1790,16 +1790,16 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2421,9 +2421,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3415,9 +3415,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -3921,9 +3921,9 @@
       "license": "MIT"
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4673,16 +4673,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -4929,13 +4919,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,10 @@
     "lint:fix": "biome check --write .",
     "lint:ci": "biome ci ."
   },
+  "overrides": {
+    "diff": "^8.0.4",
+    "serialize-javascript": "^7.0.7"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.5.6",
     "@sinonjs/fake-timers": "^15.4.0",


### PR DESCRIPTION
## Summary

`npm audit` reported several advisories, all of them reachable only through devDependencies -- this extension has no runtime `dependencies` -- so none of them ship in the packaged `.vsix`. This PR takes the count to **0**.

## What was done

`npm audit fix` clears the ones that sit inside an already-permitted semver range:

| Package | Before | After |
|---|---|---|
| brace-expansion | 2.1.2 / 5.0.7 | 2.1.4 / 5.0.9 |
| js-yaml | 4.2.0 | 4.3.1 |

The rest come from mocha, which still declares `diff: ^7.0.0` and `serialize-javascript: ^6.0.2` -- both entirely inside the vulnerable ranges, so there is no version of mocha to upgrade to. They are pulled up through `overrides` instead:

```json
"overrides": {
  "diff": "^8.0.4",
  "serialize-javascript": "^7.0.7"
}
```

This resolves diff to 8.0.4 and serialize-javascript to 7.0.7. mocha stays on 11.7.6 and sinon on 22.1.0, both untouched.

## Why not `npm audit fix --force`

It resolves those advisories by **downgrading `@vscode/test-cli` from 0.0.15 to 0.0.11**, dragging yargs 18 to 17 and test-exclude 8 to 6 along with it. That is a regression rather than a fix, so the toolchain is left on its current versions and only the two transitive dependencies move.

## Verification

Both overrides cross a major version, so mocha 11.7.6 was exercised against them directly:

- spec reporter string diffs and object diffs render correctly
- json reporter works
- `--parallel` works (it serializes worker results through serialize-javascript)

In this repository:

- `npm audit` -> `found 0 vulnerabilities`
- `npm test` -> 58 passing
- `npm run lint`, `npm run typecheck`, `npm run package` -> all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)