### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-06
+
 ### Added
 
 - The original colors are now restored automatically on the next startup after quitting VS Code with gaming mode running
@@ -38,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/akiomik/vscode-gaming/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/akiomik/vscode-gaming/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/akiomik/vscode-gaming/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/akiomik/vscode-gaming/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/akiomik/vscode-gaming/releases/tag/v0.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-gaming",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-gaming",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@biomejs/biome": "^2.5.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/akiomik/vscode-gaming/issues"
   },
   "license": "Apache-2.0",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
Prepare the v0.2.0 release.

Depends on #55 — merge that first so the released section no longer lists the startup restore twice. This PR does not touch those lines, so it merges cleanly on top.

## Changes

- Bump the version to `0.2.0` in `package.json` and `package-lock.json`
- Promote the `Unreleased` section of `CHANGELOG.md` to `[0.2.0] - 2026-08-06` and update the comparison links

## Release notes for v0.2.0

### Added

- The original colors are now restored automatically on the next startup after quitting VS Code with gaming mode running

### Fixed

- Gaming mode no longer overwrites color customizations outside of `gaming.targets`
- Reset no longer changes `workbench.colorCustomizations` when gaming mode has never been started
- Reset no longer restores a gaming color after gaming mode has been stopped and started again

The release is a minor bump because it adds behavior on top of v0.1.0 without removing or changing any existing command or setting.

## After merging

Publishing to the Marketplace is driven by `.github/workflows/publish.yml`, which runs on `release: published`. Create the `v0.2.0` GitHub Release once this is merged to trigger it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)