### PR TITLE
docs: drop the duplicated changelog entry for the startup restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Gaming mode no longer overwrites color customizations outside of `gaming.targets`
 - Reset no longer changes `workbench.colorCustomizations` when gaming mode has never been started
-- The original colors are no longer unrecoverable after quitting VS Code with gaming mode running
 - Reset no longer restores a gaming color after gaming mode has been stopped and started again
 
 ## [0.1.0] - 2023-12-26


### PR DESCRIPTION
The `Unreleased` section of `CHANGELOG.md` describes the automatic restore of the original colors twice:

- Added: "The original colors are now restored automatically on the next startup after quitting VS Code with gaming mode running"
- Fixed: "The original colors are no longer unrecoverable after quitting VS Code with gaming mode running"

Both lines were introduced by the same commit (`0c8612e feat: restore the original colors after a VS Code restart`) and describe the same user-facing behavior from two angles, so the release notes would list one change twice.

This keeps the `Added` entry, which matches the implementation — `restoreInterrupted` runs on the next activation — and removes the duplicate `Fixed` entry.

Please merge this before #54 so the release notes there are generated from the corrected section. #54 will be rebased on top of this afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)